### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    # @items = Item.all.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# <% @items.each do |item| %> %>
+      <% @items.each do |item| %>
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%# <%= image_tag item.image, class: "item-img" if item.image.attached? %> %>
+            <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
             <%# 商品が売れていればsold outを表示しましょう %>
             <div class='sold-out'>
@@ -141,11 +141,10 @@
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%# <%= item.name %> %>
+              <%= item.name %>
             </h3>
             <div class='item-price'>
-              <%# <span><%= item.price %>円<br>
-              <%# <%= item.delivery_charge.name %></span> %> %>
+              <span><%= item.price%>円<br><%= item.delivery_charge.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -153,11 +152,11 @@
             </div>
           </div>
           <% end %>
-        <%# <% end %> %>
+        <% end %>
       </li>
 
       <%# 商品がない場合のダミー %>
-      <%# <% if @items == 0 %> %>
+      <% if @items == 0 %>
         <li class='list'>
           <%= link_to '#' do %>
           <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -175,7 +174,7 @@
           </div>
           <% end %>
         </li>
-      <%# <% end %> %>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -77,7 +77,7 @@ describe Item do
         expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
 
-      it 'priceが9999999以上だと保存できない' do 
+      it 'priceが9999999以上だと保存できない' do
         @item.price = '10000000'
         @item.valid?
         expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')


### PR DESCRIPTION
# what
トップページに商品一覧表示機能を実装。

# why


# URL
ログアウト状態でも商品一覧表示ページが見られる様子Gif 
https://gyazo.com/2fcc24dcb0436e6bc48b62fccbcf0df3

出品された日時が新しい順に表示されている様子Gif
https://gyazo.com/548ec61220fe2111c9c7e93e534fa7a0


出品機能を実装した際、商品一覧表示機能もほぼ同時に作ってしまったため、commitなど少ないです。
よろしくお願いします！